### PR TITLE
Mail log index

### DIFF
--- a/app/Http/Controllers/MailLogController.php
+++ b/app/Http/Controllers/MailLogController.php
@@ -2,9 +2,42 @@
 
 namespace App\Http\Controllers;
 
+use App\Helpers\FlashBannerHelper;
+use App\Models\MailLog;
 use Illuminate\Http\Request;
+use Inertia\Inertia;
 
 class MailLogController extends Controller
 {
-    //
+    public function index()
+    {
+        $domainId = request()->domain_id;
+
+        $user = request()->user();
+
+        if($domainId && !$user->canAccessDomainData($domainId)) {
+            abort(403);
+        }
+
+        $domains = $user->getDomainsForSelect();
+
+        $logs = MailLog::query()
+            ->where('domain_id', $domainId)
+            ->when(request()->input('search'), function($q, $search) {
+                $q->where(function($q) use ($search) {
+                    $q->whereLike('message_to', $search)
+                        ->orWhereLike('subject', $search);
+                });
+            })
+            ->orderByDesc('timestamp')
+            ->paginate(15)
+            ->withQueryString();
+
+        return Inertia::render('MailLogs/List', [
+            'logs' => $logs,
+            'filters' => request()->only('search', 'domain_id'),
+            'domains' => $domains,
+        ]);
+    }
+
 }

--- a/app/Http/Controllers/MailLogController.php
+++ b/app/Http/Controllers/MailLogController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Helpers\FlashBannerHelper;
 use App\Models\MailLog;
-use Illuminate\Http\Request;
+use Carbon\Carbon;
 use Inertia\Inertia;
 
 class MailLogController extends Controller
@@ -19,10 +19,16 @@ class MailLogController extends Controller
             abort(403);
         }
 
-        $domains = $user->getDomainsForSelect();
+        $filters = request()->only(['domain_id', 'search']);
+        $filters['date_from'] = request()->date_from ?: Carbon::now()->format('Y-m-d');
+        $filters['date_to'] = request()->date_to ?: Carbon::now()->format('Y-m-d');
 
         $logs = MailLog::query()
             ->where('domain_id', $domainId)
+            ->whereBetween('timestamp', [$filters['date_from'], $filters['date_to']])
+            ->when(request()->input('event'), function($q, $event) {
+                $q->where('event', $event);
+            })
             ->when(request()->input('search'), function($q, $search) {
                 $q->where(function($q) use ($search) {
                     $q->whereLike('message_to', $search)
@@ -33,10 +39,15 @@ class MailLogController extends Controller
             ->paginate(15)
             ->withQueryString();
 
+        $domains = $user->getDomainsForSelect();
+
+        $events = MailLog::getEventsForSelect();
+
         return Inertia::render('MailLogs/List', [
             'logs' => $logs,
-            'filters' => request()->only('search', 'domain_id'),
+            'filters' => $filters,
             'domains' => $domains,
+            'events' => $events,
         ]);
     }
 

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -3,6 +3,7 @@
 namespace App\Http;
 
 use App\Http\Middleware\AdminAuth;
+use App\Http\Middleware\CustomerAuth;
 use Illuminate\Foundation\Http\Kernel as HttpKernel;
 
 class Kernel extends HttpKernel
@@ -66,5 +67,6 @@ class Kernel extends HttpKernel
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
         'admin' => AdminAuth::class,
+        'customer' => CustomerAuth::class,
     ];
 }

--- a/app/Http/Middleware/CustomerAuth.php
+++ b/app/Http/Middleware/CustomerAuth.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\User;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class CustomerAuth
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  Request  $request
+     * @param  Closure  $next
+     * @return mixed
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        $user = Auth::user();
+
+        if($user->role != User::ROLE_CUSTOMER || $user->role != User::ROLE_ADMIN) {
+            abort(403, 'Unauthorized action.');
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/CustomerAuth.php
+++ b/app/Http/Middleware/CustomerAuth.php
@@ -20,7 +20,7 @@ class CustomerAuth
     {
         $user = Auth::user();
 
-        if($user->role != User::ROLE_CUSTOMER || $user->role != User::ROLE_ADMIN) {
+        if($user->role != User::ROLE_CUSTOMER && $user->role != User::ROLE_ADMIN) {
             abort(403, 'Unauthorized action.');
         }
 

--- a/app/Models/Domain.php
+++ b/app/Models/Domain.php
@@ -18,9 +18,14 @@ class Domain extends Model
         'name',
     ];
 
-  public function users()
+    public function users()
     {
         return $this->belongsToMany(User::class);
+    }
+
+    public function mailLogs()
+    {
+        return $this->hasMany(MailLog::class);
     }
 
 }

--- a/app/Models/MailLog.php
+++ b/app/Models/MailLog.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
 
 class MailLog extends Model
 {
@@ -26,4 +27,18 @@ class MailLog extends Model
         self::EVENT_TEMPORARY_FAIL,
         self::EVENT_PERMANENT_FAIL,
     ];
+
+    public static function getEventsForSelect(): Collection
+    {
+        return collect([
+            ['id' => null, 'name' => 'Todos'],
+            ['id' => self::EVENT_ACCEPTED, 'name' => self::EVENT_ACCEPTED],
+            ['id' => self::EVENT_DELIVERED, 'name' => self::EVENT_DELIVERED],
+            ['id' => self::EVENT_OPENED, 'name' => self::EVENT_OPENED],
+            ['id' => self::EVENT_REJECTED, 'name' => self::EVENT_REJECTED],
+            ['id' => self::EVENT_COMPLAINED, 'name' => self::EVENT_COMPLAINED],
+            ['id' => self::EVENT_TEMPORARY_FAIL, 'name' => self::EVENT_TEMPORARY_FAIL],
+            ['id' => self::EVENT_PERMANENT_FAIL, 'name' => self::EVENT_PERMANENT_FAIL],
+        ]);
+    }
 }

--- a/app/Models/MailLog.php
+++ b/app/Models/MailLog.php
@@ -8,4 +8,22 @@ use Illuminate\Database\Eloquent\Model;
 class MailLog extends Model
 {
     use HasFactory;
+
+    const EVENT_ACCEPTED = 'Accepted';
+    const EVENT_DELIVERED = 'Delivered';
+    const EVENT_OPENED = 'Opened';
+    const EVENT_REJECTED = 'Rejected';
+    const EVENT_COMPLAINED = 'Complained';
+    const EVENT_TEMPORARY_FAIL = 'Temporary Fail';
+    const EVENT_PERMANENT_FAIL = 'Permanent Fail';
+
+    public static array $events = [
+        self::EVENT_ACCEPTED,
+        self::EVENT_DELIVERED,
+        self::EVENT_OPENED,
+        self::EVENT_REJECTED,
+        self::EVENT_COMPLAINED,
+        self::EVENT_TEMPORARY_FAIL,
+        self::EVENT_PERMANENT_FAIL,
+    ];
 }

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         "laravel/jetstream": "^2.6",
         "laravel/sanctum": "^2.11",
         "laravel/tinker": "^2.5",
-        "tightenco/ziggy": "^1.4"
+        "tightenco/ziggy": "^1.4",
+        "ext-json": "*"
     },
     "require-dev": {
         "facade/ignition": "^2.5",

--- a/database/factories/MailLogFactory.php
+++ b/database/factories/MailLogFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\MailLog;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class MailLogFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = MailLog::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'mailgun_id' => $this->faker->uuid3(),
+            'event' => $this->faker->randomElement(MailLog::$events),
+            'message_to' => $this->faker->email,
+            'message_from' => $this->faker->email,
+            'subject' => $this->faker->text(30),
+            'timestamp' => $this->faker->dateTimeBetween(Carbon::now()->subDays(15), Carbon::now()),
+            'data' => json_encode([]),
+        ];
+    }
+}

--- a/database/seeders/MailLogSeeder.php
+++ b/database/seeders/MailLogSeeder.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Domain;
+use App\Models\MailLog;
+use Illuminate\Database\Seeder;
+
+class MailLogSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        Domain::factory()
+            ->count(5)
+            ->has(MailLog::factory()->count(100))
+            ->create();
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4922,6 +4922,11 @@
                 "minimist": "^1.2.5"
             }
         },
+        "moment": {
+            "version": "2.29.1",
+            "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+            "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+        },
         "ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -6970,6 +6975,14 @@
                         "json5": "^2.1.2"
                     }
                 }
+            }
+        },
+        "vue-moment": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/vue-moment/-/vue-moment-4.1.0.tgz",
+            "integrity": "sha512-Gzisqpg82ItlrUyiD9d0Kfru+JorW2o4mQOH06lEDZNgxci0tv/fua1Hl0bo4DozDV2JK1r52Atn/8QVCu8qQw==",
+            "requires": {
+                "moment": "^2.19.2"
             }
         },
         "vue-style-loader": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
         "vue-loader": "^16.1.2"
     },
     "dependencies": {
+        "vue-moment": "^4.1.0",
         "ziggy-js": "^1.4.2"
     }
 }

--- a/resources/js/CustomComponents/ListBox.vue
+++ b/resources/js/CustomComponents/ListBox.vue
@@ -107,12 +107,18 @@ export default {
         document.addEventListener('keydown', closeOnEscape)
     },
     mounted() {
-        const option = this.options.find(
-            option => option.id.toString() === this.$attrs.modelValue.toString()
-        )
+        const val = this.$attrs.modelValue
 
-        if (option)
-            this.select(option)
+        if(val) {
+            const option = this.options.find(
+                option => option.id.toString() === val.toString()
+            )
+
+            if (option) {
+                this.select(option)
+            }
+        }
+
     },
     methods: {
         select($option) {

--- a/resources/js/CustomComponents/ListBox.vue
+++ b/resources/js/CustomComponents/ListBox.vue
@@ -107,7 +107,9 @@ export default {
         document.addEventListener('keydown', closeOnEscape)
     },
     mounted() {
-        var option = this.options.find(option => option.id === this.$attrs.modelValue)
+        const option = this.options.find(
+            option => option.id.toString() === this.$attrs.modelValue.toString()
+        )
 
         if (option)
             this.select(option)

--- a/resources/js/Layouts/AppLayout.vue
+++ b/resources/js/Layouts/AppLayout.vue
@@ -23,6 +23,7 @@
                                     Dashboard
                                 </jet-nav-link>
 
+                                <!--Admin-->
                                 <template v-if="$page.props.user.role === roleAdmin()">
                                     <jet-nav-link :href="route('users.index')" :active="route().current('users.index')">
                                         Usuarios
@@ -31,6 +32,16 @@
                                         Dominios
                                     </jet-nav-link>
                                 </template>
+                                <!--End Admin-->
+
+                                <!--Customer-->
+                                <template v-if="$page.props.user.role === roleAdmin() || $page.props.user.role === roleCustomer() ">
+                                    <jet-nav-link :href="route('mail-logs.index')" :active="route().current('mail-logs.index')">
+                                        Registros
+                                    </jet-nav-link>
+                                </template>
+                                <!--End Customer-->
+
                             </div>
                         </div>
 
@@ -165,6 +176,14 @@
                             </jet-responsive-nav-link>
                         </template>
                         <!--End Admin-->
+
+                        <!--Customer-->
+                        <template v-if="$page.props.user.role === roleAdmin() || $page.props.user.role === roleCustomer() ">
+                            <jet-responsive-nav-link :href="route('mail-logs.index')" :active="route().current('mail-logs.index')">
+                                Registros
+                            </jet-responsive-nav-link>
+                        </template>
+                        <!--End Customer-->
 
                     </div>
 

--- a/resources/js/Pages/MailLogs/List.vue
+++ b/resources/js/Pages/MailLogs/List.vue
@@ -1,0 +1,173 @@
+<template>
+    <app-layout title="Registros">
+        <template #header>
+            <div class="lg:flex lg:items-center lg:justify-between">
+                <div class="flex-1 min-w-0">
+                    <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+                        Registros
+                    </h2>
+                </div>
+                <div class="mt-5 flex lg:mt-0 lg:ml-4">
+                </div>
+            </div>
+        </template>
+
+        <div class="py-12">
+            <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+
+                <!--Filtros-->
+                <div>
+                    <div class="mb-2 text-gray-900">
+                        Filtros
+                    </div>
+                    <div class="mb-6 grid grid-cols-12 gap-x-4 gap-y-2">
+
+                        <!-- domain_id -->
+                        <div class="md:col-span-3 col-span-6">
+                            <my-list-box
+                                id="domain_id"
+                                v-model="domain_id"
+                                @input="val => domain_id = val"
+                                :options="domains"
+                                @selected="domain_id"
+                            >
+                                <template #header>
+                                    <jet-label for="type" value="Dominio" />
+                                </template>
+                            </my-list-box>
+                        </div>
+
+                        <!-- search -->
+                        <div class="md:col-span-3 col-span-6">
+                            <jet-label value="Buscar" />
+                            <jet-input type="text" class="mt-1 block w-full" v-model="search"/>
+                        </div>
+
+                    </div>
+                </div>
+
+                <div class="flex flex-col">
+                    <div class="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+                        <div class="py-2 align-middle inline-block min-w-full sm:px-6 lg:px-8">
+                            <div class="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg">
+                                <table class="min-w-full divide-y divide-gray-200">
+                                    <thead class="bg-gray-50">
+                                    <tr>
+                                        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                            Fecha
+                                        </th>
+                                        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                            Evento
+                                        </th>
+                                        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                            Enviado a
+                                        </th>
+                                        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                            Asunto
+                                        </th>
+                                        <th scope="col" class="relative px-6 py-3">
+                                            <span class="sr-only">Acciones</span>
+                                        </th>
+                                    </tr>
+                                    </thead>
+                                    <tbody class="bg-white divide-y divide-gray-200">
+                                        <tr v-for="log in logs.data">
+                                            <td class="px-6 py-4 whitespace-nowrap">
+                                                <div class="text-sm text-gray-900">{{ log.timestamp}}</div>
+                                            </td>
+                                            <td class="px-6 py-4 whitespace-nowrap">
+                                                <div class="text-sm text-gray-900">{{ log.event}}</div>
+                                            </td>
+                                            <td class="px-6 py-4 whitespace-nowrap">
+                                                <div class="text-sm text-gray-900">{{ log.message_to}}</div>
+                                            </td>
+                                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                                                <div class="text-sm text-gray-900">{{ log.subject}}</div>
+                                            </td>
+                                            <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+<!--                                                <Link :href="route('users.edit', {user: user.id})" class="ml-4 text-indigo-600 hover:text-indigo-900">Editar</Link>-->
+                                            </td>
+                                        </tr>
+                                        <tr>
+                                            <td class="px-6 py-4 whitespace-nowrap" colspan="5" v-if="logs.data.length === 0">
+                                                <div class="text-sm text-gray-900 text-center">No se encontraron registros. Revise los filtros y seleccione un dominio.</div>
+                                            </td>
+                                        </tr>
+
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <Pagination :links="logs.links" />
+
+            </div>
+        </div>
+    </app-layout>
+</template>
+
+<script>
+import AppLayout from '@/Layouts/AppLayout.vue'
+import { Link } from '@inertiajs/inertia-vue3';
+import MyButtonLink from '@/CustomComponents/ButtonLink.vue'
+import JetNavLink from '@/Jetstream/NavLink.vue'
+import Pagination from "@/CustomComponents/Pagination";
+import MyListBox from "@/CustomComponents/ListBox";
+import JetInput from "@/Jetstream/Input";
+import JetLabel from "@/Jetstream/Label";
+import {Inertia} from "@inertiajs/inertia";
+
+
+export default {
+    props: {
+        logs: Object,
+        filters: Object,
+        domains: Array,
+    },
+
+    components: {
+        AppLayout,
+        MyButtonLink,
+        JetNavLink,
+        Link,
+        Pagination,
+        JetLabel,
+        JetInput,
+        MyListBox,
+    },
+
+    data() {
+        return {
+            confirmingDeletion: false,
+            form: this.$inertia.form({
+                id: null,
+                name: '',
+            }),
+            domain_id: this.filters.domain_id,
+            search: this.filters.search,
+        }
+    },
+
+    methods: {
+        filter() {
+            Inertia.get(
+                route('mail-logs.index'), {
+                    domain_id: this.domain_id,
+                    search: this.search
+                },
+                {
+                    preserveState: true,
+                    replace: true,
+                },
+            )
+        },
+    },
+
+    watch: {
+        search: function() { this.filter() },
+        domain_id: function() { this.filter() },
+    },
+}
+</script>

--- a/resources/js/Pages/MailLogs/List.vue
+++ b/resources/js/Pages/MailLogs/List.vue
@@ -15,11 +15,12 @@
         <div class="py-12">
             <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
 
-                <!--Filtros-->
+                <!--Filters-->
                 <div>
                     <div class="mb-2 text-gray-900">
                         Filtros
                     </div>
+
                     <div class="mb-6 grid grid-cols-12 gap-x-4 gap-y-2">
 
                         <!-- domain_id -->
@@ -37,13 +38,44 @@
                             </my-list-box>
                         </div>
 
-                        <!-- search -->
-                        <div class="md:col-span-3 col-span-6">
-                            <jet-label value="Buscar" />
-                            <jet-input type="text" class="mt-1 block w-full" v-model="search"/>
+                        <!-- date_from -->
+                        <div class="md:col-span-2 col-span-6">
+                            <jet-label value="Fecha Desde" />
+                            <my-date-picker v-model="date_from" :value="date_from"/>
+                        </div>
+
+                        <!-- date_to -->
+                        <div class="md:col-span-2 col-span-6">
+                            <jet-label value="Fecha Hasta" />
+                            <my-date-picker  v-model="date_to" :value="date_to"/>
                         </div>
 
                     </div>
+
+                    <div class="mb-6 grid grid-cols-12 gap-x-4 gap-y-2">
+
+                        <!-- event -->
+                        <div class="md:col-span-3 col-span-6">
+                            <my-list-box
+                                id="event"
+                                v-model="event"
+                                @input="val => event = val"
+                                :options="events"
+                                @selected="event"
+                            >
+                                <template #header>
+                                    <jet-label for="type" value="Evento" />
+                                </template>
+                            </my-list-box>
+                        </div>
+
+                        <!-- search -->
+                        <div class="md:col-span-3 col-span-6">
+                            <jet-label value="Buscar por Correo o Asunto" />
+                            <jet-input type="text" class="mt-1 block w-full" v-model="search"/>
+                        </div>
+                    </div>
+
                 </div>
 
                 <div class="flex flex-col">
@@ -118,13 +150,14 @@ import MyListBox from "@/CustomComponents/ListBox";
 import JetInput from "@/Jetstream/Input";
 import JetLabel from "@/Jetstream/Label";
 import {Inertia} from "@inertiajs/inertia";
-
+import MyDatePicker from "@/CustomComponents/DatePicker";
 
 export default {
     props: {
         logs: Object,
         filters: Object,
         domains: Array,
+        events: Array,
     },
 
     components: {
@@ -136,6 +169,7 @@ export default {
         JetLabel,
         JetInput,
         MyListBox,
+        MyDatePicker,
     },
 
     data() {
@@ -146,6 +180,9 @@ export default {
                 name: '',
             }),
             domain_id: this.filters.domain_id,
+            date_from: this.filters.date_from,
+            date_to: this.filters.date_to,
+            event: this.filters.event,
             search: this.filters.search,
         }
     },
@@ -155,7 +192,10 @@ export default {
             Inertia.get(
                 route('mail-logs.index'), {
                     domain_id: this.domain_id,
-                    search: this.search
+                    date_from: this.date_from,
+                    date_to: this.date_to,
+                    event: this.event,
+                    search: this.search,
                 },
                 {
                     preserveState: true,
@@ -166,8 +206,11 @@ export default {
     },
 
     watch: {
-        search: function() { this.filter() },
         domain_id: function() { this.filter() },
+        date_from: function() { this.filter() },
+        date_to: function() { this.filter() },
+        event: function() { this.filter() },
+        search: function() { this.filter() },
     },
 }
 </script>

--- a/routes/web.php
+++ b/routes/web.php
@@ -26,9 +26,9 @@ Route::middleware(['auth:sanctum', 'verified'])->get('/dashboard', function () {
 
 /*
  * Admin Routes
- * todo: middleware for admin and customer
  * - Users
  * - Domains
+ * - User Domain
  * */
 
 Route::middleware('admin')->group(function() {
@@ -46,6 +46,8 @@ Route::middleware('admin')->group(function() {
     Route::resource('domains', \App\Http\Controllers\DomainController::class)
         ->middleware(['auth:sanctum', 'verified']);
 
+    // User Domains
+
     Route::get('user-domains/{user}', [\App\Http\Controllers\UserDomainController::class, 'index'])
         ->middleware(['auth:sanctum', 'verified'])->name('user-domain.index');
 
@@ -56,4 +58,21 @@ Route::middleware('admin')->group(function() {
         ->middleware(['auth:sanctum', 'verified'])->name('user-domain.destroy');
 
 });
+
+
+/*
+ * Customers Routes
+ * - Mail Logs
+ * */
+
+Route::middleware('customer')->group(function() {
+
+    // Mail Logs
+
+    Route::get('mail-logs', [\App\Http\Controllers\MailLogController::class, 'index'])
+        ->middleware(['auth:sanctum', 'verified'])->name('mail-logs.index');
+
+});
+
+
 


### PR DESCRIPTION
This PR adds an Index for the Mail Logs.

It provides several filters like domain, date (from, to),  event and a text search for email and subject.

You must select a domain in order to get the logs.

A Middleware is used to prevent access.

There is also a verification to ensure that the users has access to the domains logs requested.

In order to test the index, there is a MailLogSeeder, that create 5 domains with 100 Logs in each.


